### PR TITLE
added mobile responsiveness to auth components and pages

### DIFF
--- a/src/app/(auth)/auth-error/page.tsx
+++ b/src/app/(auth)/auth-error/page.tsx
@@ -1,19 +1,20 @@
-import { CardWrapper } from '@/components/auth/CardWrapper'
-import React from 'react'
-import { FaExclamationTriangle } from 'react-icons/fa'
+import { CardWrapper } from "@/components/auth/CardWrapper";
+import React from "react";
+import { FaExclamationTriangle } from "react-icons/fa";
 
 const AuthErrorPage = () => {
   return (
     <CardWrapper
-    header="Something went wrong!"
-    headerLabel="Oops, try again in a few minutes"
-    backButtonHref="/login"
-    backButtonLabel="Return to login">
-      <div className='flex items-center justify-center py-4'>
-      <FaExclamationTriangle size={38} color='#FF304D'/>
+      header="Something went wrong!"
+      headerLabel="Oops, try again in a few minutes"
+      backButtonHref="/login"
+      backButtonLabel="Return to login"
+    >
+      <div className="flex items-center justify-center py-4">
+        <FaExclamationTriangle size={38} color="#FF304D" />
       </div>
     </CardWrapper>
-  )
-}
+  );
+};
 
-export default AuthErrorPage
+export default AuthErrorPage;

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,10 +1,8 @@
-import { ForgotPasswordForm } from '@/components/auth/ForgotPasswordForm'
-import React from 'react'
+import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm";
+import React from "react";
 
 const ForgotPasswordPage = () => {
-  return (
-    <ForgotPasswordForm/>
-  )
-}
+  return <ForgotPasswordForm />;
+};
 
-export default ForgotPasswordPage
+export default ForgotPasswordPage;

--- a/src/app/(auth)/new-verification/page.tsx
+++ b/src/app/(auth)/new-verification/page.tsx
@@ -2,11 +2,11 @@ import VerificationWidget from "@/components/auth/VerificationWidget";
 import { Suspense } from "react";
 
 const NewVerificationPage = () => {
- return (
-  <Suspense>
-    <VerificationWidget/>
-  </Suspense>
- )
+  return (
+    <Suspense>
+      <VerificationWidget />
+    </Suspense>
+  );
 };
 
 export default NewVerificationPage;

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,12 +1,12 @@
-import { ResetPasswordForm } from '@/components/auth/ResetPasswordForm'
-import React, { Suspense } from 'react'
+import { ResetPasswordForm } from "@/components/auth/ResetPasswordForm";
+import React, { Suspense } from "react";
 
 const ResetPasswordPage = () => {
   return (
     <Suspense>
-      <ResetPasswordForm/>
+      <ResetPasswordForm />
     </Suspense>
-  )
-}
+  );
+};
 
-export default ResetPasswordPage
+export default ResetPasswordPage;

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,7 +1,5 @@
 import { SignUpForm } from "@/components/auth/SignUpForm";
 
 export default function SignUpPage() {
-  return (
-    <SignUpForm/>
-  )
+  return <SignUpForm />;
 }

--- a/src/components/auth/BackButton.tsx
+++ b/src/components/auth/BackButton.tsx
@@ -8,8 +8,13 @@ interface BackButtonProps {
 
 export const BackButton = ({ href, label }: BackButtonProps) => {
   return (
-    <Button variant="link" className="font-medium w-full mt-3" size="sm" asChild>
+    <Button
+      variant="link"
+      className="font-medium w-full mt-3"
+      size="sm"
+      asChild
+    >
       <Link href={href}>{label}</Link>
     </Button>
   );
-}
+};

--- a/src/components/auth/CardWrapper.tsx
+++ b/src/components/auth/CardWrapper.tsx
@@ -31,7 +31,10 @@ export const CardWrapper = ({
   showTerms,
 }: CardWrapperProps) => {
   return (
-    <Card className="min-w-[520px] max-w-[40%]" variant="glass">
+    <Card
+      className="max-w-[80%] sm:max-w-[70%] md:max-w-[520px]"
+      variant="glass"
+    >
       <CardHeader>
         <Header header={header} label={headerLabel} />
       </CardHeader>

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -64,6 +64,7 @@ export const ForgotPasswordForm = () => {
                   <FormLabel>Email Address</FormLabel>
                   <FormControl>
                     <Input
+                      variant="greenFilled"
                       disabled={isPending}
                       {...field}
                       placeholder="zelda_hyrule@live.com"
@@ -77,7 +78,7 @@ export const ForgotPasswordForm = () => {
           </div>
           <Button
             size="full"
-            className="font-bold text-md"
+            className="font-bold"
             type="submit"
             disabled={isPending}
           >

--- a/src/components/auth/Header.tsx
+++ b/src/components/auth/Header.tsx
@@ -3,16 +3,15 @@ interface HeaderProps {
   label: string;
 }
 
-export const Header = ({header, label}: HeaderProps) => {
+export const Header = ({ header, label }: HeaderProps) => {
   return (
     <div className="space-y-1">
-      <h1 className="text-white font-semibold text-3xl">
+      <h1 className="text-white font-semibold text-lg sm:text-xl md:text-3xl">
         {header}
       </h1>
-      <p className="text-lightGrey font-light text-lg">
+      <p className="text-lightGrey font-light text-sm sm:text-base md:text-lg">
         {label}
       </p>
     </div>
-    
-  )
-}
+  );
+};

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -20,12 +20,14 @@ import { Button } from "../ui/button";
 import { login } from "@/actions/login";
 import { FormError } from "@/components/forms/FormError";
 import { FormSuccess } from "@/components/forms/FormSuccess";
-import { BackButton } from "./BackButton";
 import { useSearchParams } from "next/navigation";
 
 export const LoginForm = () => {
-  const searchParams = useSearchParams()
-  const urlOAuthError = searchParams.get('error') === "OAuthAccountNotLinked" ? "Email already in use with different provider!" : ""
+  const searchParams = useSearchParams();
+  const urlOAuthError =
+    searchParams.get("error") === "OAuthAccountNotLinked"
+      ? "Email already in use with different provider!"
+      : "";
 
   const [error, setError] = useState<string | undefined>("");
   const [success, setSuccess] = useState<string | undefined>("");
@@ -73,6 +75,7 @@ export const LoginForm = () => {
                   <FormLabel>Email Address</FormLabel>
                   <FormControl>
                     <Input
+                      variant="greenFilled"
                       disabled={isPending}
                       {...field}
                       placeholder="mario_bros@gmail.com"
@@ -92,6 +95,7 @@ export const LoginForm = () => {
                     <FormLabel>Password</FormLabel>
                     <FormControl>
                       <Input
+                        variant="greenFilled"
                         disabled={isPending}
                         {...field}
                         placeholder="••••••••"
@@ -114,7 +118,7 @@ export const LoginForm = () => {
           </div>
           <Button
             size="full"
-            className="font-bold text-md"
+            className="font-bold"
             type="submit"
             disabled={isPending}
           >

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -68,6 +68,7 @@ export const ResetPasswordForm = () => {
                   <FormLabel>New password</FormLabel>
                   <FormControl>
                     <Input
+                      variant="greenFilled"
                       disabled={isPending}
                       {...field}
                       placeholder="••••••••"
@@ -81,7 +82,7 @@ export const ResetPasswordForm = () => {
           </div>
           <Button
             size="full"
-            className="font-bold text-md"
+            className="font-bold"
             type="submit"
             disabled={isPending}
           >

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -67,6 +67,7 @@ export const SignUpForm = () => {
                   <FormLabel className="">Email Address</FormLabel>
                   <FormControl>
                     <Input
+                      variant="greenFilled"
                       disabled={isPending}
                       {...field}
                       placeholder="spiderman@gmail.com"
@@ -85,6 +86,7 @@ export const SignUpForm = () => {
                   <FormLabel>Password</FormLabel>
                   <FormControl>
                     <Input
+                      variant="greenFilled"
                       disabled={isPending}
                       {...field}
                       placeholder="••••••••"
@@ -98,7 +100,7 @@ export const SignUpForm = () => {
           </div>
           <Button
             size="full"
-            className="font-bold text-md"
+            className="font-bold"
             type="submit"
             disabled={isPending}
           >

--- a/src/components/auth/Social.tsx
+++ b/src/components/auth/Social.tsx
@@ -13,41 +13,47 @@ export const Social = () => {
 
   return (
     <>
-      <div className="my-4 flex basis-full text-lightGrey font-thin before:bg-[#707070] before:h-px before:grow before:mr-4 before:mt-2 after:bg-[#707070] after:h-px after:grow items-center after:ml-4 after:mt-2">
+      <div className="my-4 text-xs sm:text-sm md:text-base flex basis-full text-lightGrey font-thin before:bg-[#707070] before:h-px before:grow before:mr-4 before:mt-2 after:bg-[#707070] after:h-px after:grow items-center after:ml-4 after:mt-2">
         or
       </div>
       <div className="flex flex-col items-center w-full gap-y-2 mt-4 ">
         <Button
           size="full"
-          className="gap-7"
+          className="gap-4 sm:gap-5 md:gap-7"
           variant="social"
           onClick={() => {
             onClick("google");
           }}
         >
-          <FcGoogle size={24} />
+          <div className="w-4 h-4 sm:w-5 sm:h-5 md:w-6 md:h-6">
+            <FcGoogle size="auto" />
+          </div>
           Continue with Google
         </Button>
         <Button
           size="full"
-          className="gap-7"
+          className="gap-4 sm:gap-5 md:gap-7"
           variant="social"
           onClick={() => {
             onClick("twitch");
           }}
         >
-          <FaTwitch size={24} color="#9146FF"/>
+          <div className="w-4 h-4 sm:w-5 sm:h-5 md:w-6 md:h-6">
+            <FaTwitch size="auto" color="#9146FF" />
+          </div>
           Continue with Twitch
         </Button>
         <Button
           size="full"
-          className="gap-7"
+          className="gap-4 sm:gap-5 md:gap-7"
           variant="social"
           onClick={() => {
             onClick("discord");
           }}
         >
-          <FaDiscord size={24} color="#5865F2" />
+          <div className="w-4 h-4 sm:w-5 sm:h-5 md:w-6 md:h-6">
+            <FaDiscord size="auto" color="#5865F2" />
+          </div>
           Continue with Discord
         </Button>
       </div>

--- a/src/components/auth/Terms.tsx
+++ b/src/components/auth/Terms.tsx
@@ -1,14 +1,18 @@
 import Link from "next/link";
 
 export default function Terms() {
-  const TOS_HREF = "/tos"
-  const PRIVACY_HREF = "/privacy"
+  const TOS_HREF = "/tos";
+  const PRIVACY_HREF = "/privacy";
   return (
-    <div className="text-xs text-mediumGrey mt-5 font-light">
-        {'By clicking "Continue with Google / Email" you agree to our User '} 
-        <Link href={TOS_HREF} className="underline">Terms of Service</Link> 
-        {' and '}
-        <Link href={PRIVACY_HREF} className="underline">Privacy Policy</Link>
+    <div className="text-[10px] sm:text-xs text-mediumGrey mt-5 font-light">
+      {'By clicking "Continue with Google / Email" you agree to our User '}
+      <Link href={TOS_HREF} className="underline">
+        Terms of Service
+      </Link>
+      {" and "}
+      <Link href={PRIVACY_HREF} className="underline">
+        Privacy Policy
+      </Link>
     </div>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,21 +1,20 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium ring-offset-white transition-colors ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-lg font-medium ring-offset-white transition-colors ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300",
   {
     variants: {
       variant: {
-
         default: " bg-green font-semiBold text-black hover:bg-green/80",
         outline:
-        " border-lightGrey hover:border-lightPurple hover:text-lightPurple border-2 text-lightGrey",
-        social: "text-white/80 font-light border-4 border-green border-opacity-50 hover:border-opacity-100 hover:text-white",
+          " border-lightGrey hover:border-lightPurple hover:text-lightPurple border-2 text-lightGrey",
+        social:
+          "text-white/80 font-light border-4 border-green border-opacity-50 hover:border-opacity-100 hover:text-white",
         link: "text-lightGrey underline-offset-4 hover:underline",
-        
 
         // ** SHADCN UI DEFAULT STYLINGS
         // destructive:
@@ -25,11 +24,11 @@ const buttonVariants = cva(
         // ghost: "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
-        full: "h-16 w-full p-5"      
+        default: "h-10 px-4 py-2 text-sm sm:text-base",
+        sm: "h-5 sm:h-6 md:h-7 sm:h-8 md:h-9 rounded-md px-3 text-xs sm:text-sm",
+        lg: "h-9 sm:h-10 md:h-11 rounded-md px-8 text-base sm:text-lg",
+        icon: "h-8 w-8 sm:h-9 sm:w-9 md:h-10 md:w-10",
+        full: "h-12 sm:h-14 md:h-16 w-full p-3 md:p-5 text-sm sm:text-base",
       },
     },
     defaultVariants: {
@@ -37,26 +36,26 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import { cva, VariantProps } from "class-variance-authority";
 
-const cardVariants = cva("rounded-lg p-14", {
+const cardVariants = cva("rounded-lg p-10 sm:p-12 md:p-14", {
   variants: {
     variant: {
       default: "linear-gradient(180deg, #6606E3 0%, #330372 100%)",

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -95,7 +95,7 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
-      className={cn("text-white text-md", className)}
+      className={cn("text-white text-xs sm:text-sm md:text-base", className)}
       htmlFor={formItemId}
       {...props}
     />

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,21 +1,36 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { cva, VariantProps } from "class-variance-authority";
 
 // TODO: Add input styling - Default, Outline and Filled
 
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {}
+
+const inputVariants = cva(
+  "flex h-12 sm:h-14 md:h-16 w-full p-3 md:p-5 text-xs sm:text-sm md:text-base text-black rounded-md placeholder:text-black/50",
+  {
+    variants: {
+      variant: {
+        default: "linear-gradient(180deg, #6606E3 0%, #330372 100%)",
+        greenFilled:
+          "bg-green/70 hover:bg-green focus:bg-green autofill:shadow-[inset_0_0_0px_1000px_#5AE307] [&:not(:placeholder-shown)]:bg-green transition ease-in-out duration-300",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, variant, type, ...props }, ref) => {
     return (
       <input
         type={type}
-        className={cn(
-          "flex h-16 w-full rounded-md bg-green/70 p-5 text-md text-black placeholder:text-black/50 placeholder:text-md hover:bg-green focus:bg-green autofill:shadow-[inset_0_0_0px_1000px_#5AE307] [&:not(:placeholder-shown)]:bg-green transition ease-in-out duration-300",
-          className
-        )}
+        className={cn(inputVariants({ variant, className }))}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
**This PR:**
- adds mobile responsiveness to all auth components and pages
- focuses on xs, sm and md breakpoints for text, padding, height and width

||before|after|
|---|---|---|
|mobile|<img width="200" alt="Screenshot 2024-10-19 at 17 23 43" src="https://github.com/user-attachments/assets/4da51dbe-3a1b-4590-85f7-6eae06f5d157">|<img width="200" alt="Screenshot 2024-10-19 at 17 23 43" src="https://github.com/user-attachments/assets/53e52d03-7b9c-4c1f-9141-b8f029ff9a7d">|


**Steps to test:**
- go to each auth page and test mobile, tablet and laptop sizes